### PR TITLE
feat: integrate Modulino buttons

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -28,5 +28,13 @@ tasks:
    -  adb push ./python/main.py  /home/arduino/ArduinoApps/scratch-arduino-app/python/main.py
    -  adb push ./sketch/sketch.ino  /home/arduino/ArduinoApps/scratch-arduino-app/sketch/sketch.ino 
    -  adb push ./sketch/sketch.yaml  /home/arduino/ArduinoApps/scratch-arduino-app/sketch/sketch.yaml 
+   -  adb push  ./sketch/Arduino_Modulino /home/arduino/ArduinoApps/scratch-arduino-app/sketch/Arduino_Modulino  
    -  adb push ./app.yaml /home/arduino/ArduinoApps/scratch-arduino-app/app.yaml  
   #  -  adb shell arduino-app-cli app restart user:scratch-arduino-app 
+
+  modulino:patch:
+  # See https://github.com/arduino-libraries/Arduino_Modulino/pull/42
+  # Any Version<0.6.0 the build fails if Both modulino and ArduinoLedMatrix are used in the UnoQ
+    - mkdir -p sketch/Arduino_Modulino
+    - git clone --depth 1 git@github.com:arduino-libraries/Arduino_Modulino.git  sketch/Arduino_Modulino
+    - cd sketch/Arduino_Modulino && git checkout 480e9d183a3b3dede0c68170e469410a6d710bee

--- a/python/main.py
+++ b/python/main.py
@@ -3,6 +3,12 @@ from arduino.app_bricks.web_ui import WebUI
 import time
 
 ui = WebUI()
+ui.on_connect(
+    lambda sid: (
+        print(f"Client connected: {sid} "),
+    )
+)
+
 
 def on_matrix_draw(_, data):
     print(f"Received frame to draw on matrix: {data}")
@@ -22,9 +28,9 @@ def on_matrix_draw(_, data):
 
 ui.on_message("matrix_draw", on_matrix_draw)
 
-ui.on_connect(
-    lambda sid: (
-        print(f"Client connected: {sid} "),
-    )
-)
+def on_modulino_button_pressed(btn):
+    ui.send_message('modulino_buttons_pressed', {"btn": btn})
+
+Bridge.provide("modulino_button_pressed", on_modulino_button_pressed)
+
 App.run()

--- a/scratch-arduino-extensions/packages/scratch-vm/src/extensions/scratch3_arduino/index.js
+++ b/scratch-arduino-extensions/packages/scratch-vm/src/extensions/scratch3_arduino/index.js
@@ -27,6 +27,34 @@ class Scratch3Arduino {
             transports: ['polling','websocket'],
             autoConnect: true
         });
+
+        // TODO: move to ModulinoPeripheral
+        this._button_a_pressed = false;
+        this._button_b_pressed = false;
+        this._button_c_pressed = false;
+
+        this.io.on('modulino_buttons_pressed', (data) => {
+            console.log(`Modulino button pressed event received: ${data.btn}`);
+            if (data.btn.toUpperCase() == 'A'){
+                this._button_a_pressed = true;
+                this._button_b_pressed = false;
+                this._button_c_pressed = false;
+                return;
+            }
+            if (data.btn.toUpperCase() == 'B'){
+                this._button_a_pressed = false;
+                this._button_b_pressed = true;
+                this._button_c_pressed = false;
+                return;
+            }
+            if (data.btn.toUpperCase() == 'C'){
+                this._button_a_pressed = false;
+                this._button_b_pressed = false;
+                this._button_c_pressed = true;
+                return;
+            }
+            return;
+        });
    }
 };
 
@@ -49,13 +77,40 @@ Scratch3Arduino.prototype.getInfo = function () {
                         }
                     }
                 },
+                 {
+                    opcode: 'whenModulinoButtonsPressed',
+                    blockType: BlockType.HAT,
+                    text:  'when modulino button [BTN] pressed',
+                    func: 'whenModulinoButtonsPressed',
+                    arguments: {
+                        BTN: {
+                            type: ArgumentType.STRING,
+                            menu: 'modulinoButtons',
+                            defaultValue: "A"
+                        }
+                    }
+                },
             ],
+            menus: {
+                modulinoButtons: ["A", "B", "C"]
+            }
         };
 }
 
 Scratch3Arduino.prototype.matrixDraw = function (args) {
     console.log(`Drawing frame on matrix: ${args}`);
     this.io.emit("matrix_draw", {frame: args.FRAME});
+};
+
+Scratch3Arduino.prototype.whenModulinoButtonsPressed = function (args) {
+     if (args.BTN === 'A') {
+        return this._button_a_pressed
+     } else if (args.BTN === 'B') {
+        return this._button_b_pressed
+    } else if (args.BTN === 'C') {
+        return this._button_c_pressed;
+    }
+    return false;
 };
 
 module.exports = Scratch3Arduino;

--- a/sketch/sketch.ino
+++ b/sketch/sketch.ino
@@ -1,27 +1,36 @@
 #include <Arduino_RouterBridge.h>
 #include "Arduino_LED_Matrix.h"
+#include <Arduino_Modulino.h>
 
 Arduino_LED_Matrix matrix;
+ModulinoButtons buttons;
 
 void setup() {
   matrix.begin();
   Bridge.begin();
+  Modulino.begin(Wire1);
+  // show led indication if buttons cannot be initilized
+  buttons.begin(); 
+  buttons.setLeds(true, true, true);
   Bridge.provide("matrix_draw", matrix_draw);
 }
 
-void loop() {}
+void loop() {
+  if (buttons.update()) {
+      if (buttons.isPressed("A")) {
+        Bridge.notify("modulino_button_pressed", "A");
+        buttons.setLeds(true, false, false);
+      } else if (buttons.isPressed("B")) {
+        Bridge.notify("modulino_button_pressed", "B");
+        buttons.setLeds(false, true, false);
+      } else if (buttons.isPressed("C")) {
+        Bridge.notify("modulino_button_pressed", "C");
+        buttons.setLeds(false, false, true);
+      }
+  }
+}
 
-uint8_t shades[104] = {
-	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	
-	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,
-	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,
-	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,
-	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,
-	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,
-	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,
-	7,	7,	7,	7,	7,	7,	7,	7,	7,	7,	7,	7,	7,
-};
-
+uint8_t shades[104];
 
 void matrix_draw(String frame){
   if (frame.length() != 104) {

--- a/sketch/sketch.yaml
+++ b/sketch/sketch.yaml
@@ -8,10 +8,10 @@ profiles:
       - DebugLog (0.8.4)
       - ArxContainer (0.7.0)
       - ArxTypeTraits (0.3.1)
-      # - Modulino (0.5.1)
-      # - Arduino_HS300x (1.0.0)
-      # - STM32duino VL53L4CD (1.0.5)
-      # - STM32duino VL53L4ED (1.0.1)
-      # - Arduino_LSM6DSOX (1.1.2)
-      # - Arduino_LPS22HB (1.0.2)
+      - dir: Arduino_Modulino
+      - Arduino_HS300x (1.0.0)
+      - STM32duino VL53L4CD (1.0.5)
+      - STM32duino VL53L4ED (1.0.1)
+      - Arduino_LSM6DSOX (1.1.2)
+      - Arduino_LPS22HB (1.0.2)
 default_profile: default


### PR DESCRIPTION
Add ModulinoButtons scratch block.

NOTE: the `Arduino_Modulin0 < 0.6.0` is broken. Added a `task  modulino:patch` that downloads the Modulino with this [fix](https://github.com/arduino-libraries/Arduino_Modulino/pull/42),

Example

<img width="589" height="506" alt="image" src="https://github.com/user-attachments/assets/cfba0011-252b-438b-b2c3-9d6b3c7c9f70" />
