### PR TITLE
fix: full matrix brightness

### DIFF
--- a/sketch/sketch.ino
+++ b/sketch/sketch.ino
@@ -54,7 +54,7 @@ void matrix_draw(String frame){
   }
   for (int i = 0; i < 104; i++) {
     if (frame.charAt(i) == '1') {
-      shades[i] = 1;
+      shades[i] = 7; 
     } else{
       shades[i] = 0;
     }


### PR DESCRIPTION
Arduino UNO Q supports 8 level of brightness on its matrix, we should set it to the maximum 7