### PR TITLE
fi: Modify install script to stop app before removing it 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -e  # Exit immediately if any command fails
 
-# Get latest release zip URL and download
+# Get the latest release zip URL and download
 ZIP_URL=$(curl -s "https://api.github.com/repos/dido18/scratch-arduino-app/releases/latest" | \
 grep '"browser_download_url": "[^"]*\.zip"' | \
 cut -d'"' -f4 | head -n1)
@@ -19,6 +19,9 @@ echo "Downloading: $ZIP_NAME"
 cd /tmp
 curl -sL "$ZIP_URL" -o app.zip
 
+# before deleting the folder, stop it 
+arduino-app-cli app stop user:scratch-arduino-app
+
 unzip -q app.zip
 rm -rf $HOME/ArduinoApps/scratch-arduino-app
 mv -f scratch-arduino-app $HOME/ArduinoApps/
@@ -26,6 +29,6 @@ rm -f app.zip
 
 echo "Installation completed: $ZIP_NAME installed at $HOME/ArduinoApps/scratch-arduino-app"
 
-arduino-app-cli app restart user:scratch-arduino-app
+arduino-app-cli app start user:scratch-arduino-app
 arduino-app-cli properties set default user:scratch-arduino-app
 echo "Application restarted and set as default."


### PR DESCRIPTION
It seems to be a bug in the arduino-app-cli. If the app is removed, it cannot restart. The only working solution was to stop the Docker manually.