### PR TITLE
feat: enhance watch tasks with improved messaging and structure

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -156,9 +156,11 @@ tasks:
     silent: true
     cmds:
       - |
+          TOTAL_START=$(date +%s)
           /usr/bin/time -f "♾️  Compiled in %es" arduino-cli compile  --build-path .cache -b arduino:zephyr:unoq sketch/
           /usr/bin/time -f "♾️  Uploaded in %es" arduino-cli upload -p /dev/ttyACM0 -b arduino:zephyr:unoq:flash_mode=ram --input-dir .cache  sketch/
-          echo "♾️  Compiled and uploaded successfully"
+          TOTAL_END=$(date +%s)
+          echo "♾️  Total time: $((TOTAL_END - TOTAL_START))s"
       # even if not necessary: the sketch folder is sync into the board to have the updated version
       - adb push ./sketch/ /home/arduino/ArduinoApps/scratch-arduino-app/
 


### PR DESCRIPTION
- Add a task `watch` that executes the Python and Sketch watcher in parallel.
- show  the execution time for both sketch and python actions
- Polish the output with emojis for identifying Python or Sketch watcher


Usage:
```sh
❯ task watch 
♾️  Waiting for changes in sketch folder...
🐍 Waiting for changes in python folder...
```

If sketch.ino is changed


```sh
sketch/ MODIFY sketch.ino
♾️  Change detected: compiling and uploading...
The library Arduino_HS300x has been automatically added from sketch project.
The library Arduino_LPS22HB has been automatically added from sketch project.
The library Arduino_LSM6DSOX has been automatically added from sketch project.
The library Arduino_Modulino has been automatically added from sketch project.
The library ArxContainer has been automatically added from sketch project.
The library ArxTypeTraits has been automatically added from sketch project.
The library DebugLog has been automatically added from sketch project.
The library MsgPack has been automatically added from sketch project.
The library STM32duino VL53L4CD has been automatically added from sketch project.
The library STM32duino VL53L4ED has been automatically added from sketch project.
Sketch uses 23744 bytes (1%) of program storage space. Maximum is 1966080 bytes.
Global variables use 6784 bytes (1%) of dynamic memory, leaving 516840 bytes for local variables. Maximum is 523624 bytes.
♾️  Compiled in 7.19s
Open On-Chip Debugger 0.12.0+dev-ge6a2c12f4 (2025-05-22-15:51)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
debug_level: 2
clock_config
/tmp/remoteocd/sketch.elf-zsk.bin
Info : Linux GPIOD JTAG/SWD bitbang driver (libgpiod v2)
Info : Note: The adapter "linuxgpiod" doesn't support configurable speed
Info : SWD DPIDR 0x0be12477
Info : [stm32u5.ap0] Examination succeed
Info : [stm32u5.cpu] Cortex-M33 r0p4 processor detected
Info : [stm32u5.cpu] target has 8 breakpoints, 4 watchpoints
Info : [stm32u5.cpu] Examination succeed
Info : [stm32u5.ap0] gdb port disabled
Info : [stm32u5.cpu] starting gdb server on 3333
Info : Listening on port 3333 for gdb connections
CPU in Non-Secure state
[stm32u5.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x41000000 pc: 0x0801748c psp: 0x2002ccf8
[stm32u5.cpu] halted due to breakpoint, current mode: Thread 
xPSR: 0x09000000 pc: 0x0800513c psp: 0x20034a70
shutdown command invoked
20035490
New upload port: /dev/ttyACM0 (serial)
♾️  Uploaded in 7.07s
♾️  Total time: 14s
./sketch/: 2 files pushed, 0 skipped. 0.1 MB/s (2550 bytes in 0.042s)

♾️  Waiting for changes in sketch folder...
```

If python files change
```sh
python/ MODIFY main.py
🐍  Change detected: uploading and restarting service...
./python/: 1 file pushed, 0 skipped. 1.4 MB/s (2949 bytes in 0.002s)
3733f8606ceb
🐍 Restarted in 11.15s
🐍 Waiting for changes in python folder...
```