### PR TITLE
chore: fix taskfile for macos

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -86,7 +86,7 @@ tasks:
 
   app:start:
     # FIXME: workaround to force /tmp as temporary directory in not interactive command
-    - adb shell env TMPDIR=/tmp arduino-app-cli app restart user:scratch-arduino-app
+    - adb shell env TMPDIR=/tmp arduino-app-cli app start user:scratch-arduino-app
 
   watch:
     desc: "watch files changes for both python and sketch, and upload the changes to the board and restart"


### PR DESCRIPTION
The taskfile to start the app has at least three major incompatibility with macos
1. `inotifywait` is a linux only command
2. on mac there isn't gnu time by default 
3. the TMPDIR wasn't correctly set in the UNO Q in not interactive adb shell https://github.com/arduino/arduino-deb-images/issues/13