### PR TITLE
fix: remove unused library dependencies from sketch.yaml

### DIFF
--- a/.github/instructions/arduino-app.instructions.md
+++ b/.github/instructions/arduino-app.instructions.md
@@ -13,10 +13,10 @@ This instruction covers the full architecture of the Arduino App Lab running on 
 
 The Arduino UNO Q has two independent processors:
 
-| Processor | Role | Language | Entry File |
-|-----------|------|----------|------------|
-| **MPU** — Qualcomm QRB2210 | Runs Linux (Debian OS) | Python | `app/python/main.py` |
-| **MCU** — STM32U585 | Runs Arduino firmware | C++ (sketch) | `app/sketch/sketch.ino` |
+| Processor                  | Role                   | Language     | Entry File              |
+| -------------------------- | ---------------------- | ------------ | ----------------------- |
+| **MPU** — Qualcomm QRB2210 | Runs Linux (Debian OS) | Python       | `app/python/main.py`    |
+| **MCU** — STM32U585        | Runs Arduino firmware  | C++ (sketch) | `app/sketch/sketch.ino` |
 
 Both sides **communicate exclusively via the Bridge** — there is no shared memory or direct function calling between them.
 
@@ -61,6 +61,7 @@ Bridge is the **only** communication channel between Python (MPU) and the Arduin
 One side **declares** a named function that the other side can call.
 
 **In sketch (C++)**: Register a C++ function to be callable from Python.
+
 ```cpp
 // sketch.ino — setup()
 Bridge.provide("matrix_draw", matrix_draw);
@@ -69,6 +70,7 @@ Bridge.provide("servo_write", servo_write);
 ```
 
 **In Python**: Register a Python function to be callable from the sketch.
+
 ```python
 # main.py
 def on_modulino_button_pressed(btn):
@@ -82,6 +84,7 @@ Bridge.provide("modulino_button_pressed", on_modulino_button_pressed)
 One side **invokes** a function that was `provide`d on the other side.
 
 **Python → MCU**: Call a function registered with `Bridge.provide()` in the sketch.
+
 ```python
 # main.py — call a sketch function
 Bridge.call("matrix_draw", frame)
@@ -97,6 +100,7 @@ Bridge.call("servo_write", pin, angle)
 One side **pushes** data to the other without expecting a return value. Used for events/sensors.
 
 **MCU → Python**: Push an event from sketch to Python.
+
 ```cpp
 // sketch.ino — loop()
 Bridge.notify("modulino_button_pressed", "A");
@@ -115,6 +119,7 @@ Bridge.notify(...)  →  Bridge.provide(cb)  →  ui.send_message(...)
 ```
 
 **Concrete example** — Button pressed:
+
 ```
 1. User presses button A on Modulino
 2. sketch: Bridge.notify("modulino_button_pressed", "A")
@@ -133,6 +138,7 @@ ui.on_message(...)  →  Bridge.call(...)     →  Bridge.provide(fn)
 ```
 
 **Concrete example** — Draw on LED matrix:
+
 ```
 1. Browser sends WebSocket message "matrix_draw" with {frame: "...104 chars..."}
 2. python: on_matrix_draw(sid, data) fires (registered via ui.on_message)
@@ -180,6 +186,7 @@ App.run()   # MUST be the last line; starts all bricks and Bridge
 ```
 
 **Rules**:
+
 - `App.run()` must always be the **last statement** in `main.py`
 - Any code after `App.run()` will not execute
 - Use `print()` for logging — visible in the Arduino App Lab Console → "Main (Python®)" tab
@@ -242,18 +249,18 @@ Monitor.println("Sketch ready");  // visible in App Lab console
 
 ### Sketch provides (callable from Python via `Bridge.call`)
 
-| Function | Signature | Description |
-|----------|-----------|-------------|
-| `matrix_draw` | `(String frame)` | Draw 104-char greyscale string on 8×13 LED matrix (chars `0`–`7` = brightness) |
-| `set_led_rgb` | `(String pin, bool r, bool g, bool b)` | Toggle built-in RGB LEDs (`"LED3"` or `"LED4"`) |
-| `pixels_set_all_rgb` | `(int r, int g, int b)` | Set all 8 Modulino pixel LEDs to one RGB color |
-| `pixels_set_rgb` | `(int idx, int r, int g, int b)` | Set a single Modulino pixel LED by index |
-| `servo_write` | `(int pin, int angle)` | Write angle to servo (auto-attaches if not yet registered) |
+| Function             | Signature                              | Description                                                                    |
+| -------------------- | -------------------------------------- | ------------------------------------------------------------------------------ |
+| `matrix_draw`        | `(String frame)`                       | Draw 104-char greyscale string on 8×13 LED matrix (chars `0`–`7` = brightness) |
+| `set_led_rgb`        | `(String pin, bool r, bool g, bool b)` | Toggle built-in RGB LEDs (`"LED3"` or `"LED4"`)                                |
+| `pixels_set_all_rgb` | `(int r, int g, int b)`                | Set all 8 Modulino pixel LEDs to one RGB color                                 |
+| `pixels_set_rgb`     | `(int idx, int r, int g, int b)`       | Set a single Modulino pixel LED by index                                       |
+| `servo_write`        | `(int pin, int angle)`                 | Write angle to servo (auto-attaches if not yet registered)                     |
 
 ### Python provides (callable from sketch via `Bridge.notify`)
 
-| Function | Called when | Python action |
-|----------|-------------|---------------|
+| Function                  | Called when               | Python action                                         |
+| ------------------------- | ------------------------- | ----------------------------------------------------- |
 | `modulino_button_pressed` | Button A, B, or C pressed | Sends `modulino_buttons_pressed` WebSocket to browser |
 
 ---
@@ -285,13 +292,14 @@ ui.on_connect(lambda sid: print(f"Client connected: {sid}"))
 name: Scratch for Arduino UNO Q
 description: Control the UNO Q board using Scratch blocks
 ports:
-  - 7000         # Port exposed by WebUI brick
+  - 7000 # Port exposed by WebUI brick
 bricks:
   - arduino:web_ui
 icon: 🐱
 ```
 
 **Rules**:
+
 - Do **not** manually edit the `bricks:` list — use the Arduino App Lab UI to add/remove bricks
 - `ports` should list any port the app exposes externally
 
@@ -302,7 +310,7 @@ icon: 🐱
 ```yaml
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq      # Board fully-qualified board name
+    fqbn: arduino:zephyr:unoq # Board fully-qualified board name
     platforms:
       - platform: arduino:zephyr
     libraries:
@@ -314,6 +322,7 @@ default_profile: default
 ```
 
 **Rules**:
+
 - Add new Arduino libraries here, not via `#include` alone
 - The platform is always `arduino:zephyr` for UNO Q
 
@@ -367,23 +376,25 @@ Bridge.provide("my_event", on_my_event)
 ## Debugging
 
 ### Python Logs
+
 - View in: Arduino App Lab → App Console → **"Main (Python®)"** tab
 - Add `print()` statements anywhere in `main.py`
 
 ### Sketch Logs
+
 - View in: Arduino App Lab → App Console → **"Sketch (Microcontroller)"** tab
 - Use `Monitor.print()` / `Monitor.println()` — **not** `Serial.println()`
 
 ### Common Issues
 
-| Problem | Likely Cause | Fix |
-|---------|-------------|-----|
-| Bridge.call does nothing | Function not registered in sketch `setup()` | Add `Bridge.provide("name", fn)` |
-| Python function never fires | `Bridge.provide()` called after `App.run()` | Move `Bridge.provide()` before `App.run()` |
-| Browser message not received | `ui.on_message()` after `App.run()` | Move all `ui.on_message()` before `App.run()` |
-| Sketch won't compile | Missing library in `sketch.yaml` | Add library with pinned version |
-| Console shows nothing from sketch | Used `Serial.println` | Use `Monitor.println` instead |
-| App crashes on start | Exception in `main.py` before `App.run()` | Check Python tab logs for traceback |
+| Problem                           | Likely Cause                                | Fix                                           |
+| --------------------------------- | ------------------------------------------- | --------------------------------------------- |
+| Bridge.call does nothing          | Function not registered in sketch `setup()` | Add `Bridge.provide("name", fn)`              |
+| Python function never fires       | `Bridge.provide()` called after `App.run()` | Move `Bridge.provide()` before `App.run()`    |
+| Browser message not received      | `ui.on_message()` after `App.run()`         | Move all `ui.on_message()` before `App.run()` |
+| Sketch won't compile              | Missing library in `sketch.yaml`            | Add library with pinned version               |
+| Console shows nothing from sketch | Used `Serial.println`                       | Use `Monitor.println` instead                 |
+| App crashes on start              | Exception in `main.py` before `App.run()`   | Check Python tab logs for traceback           |
 
 ---
 

--- a/.github/instructions/prg-extension-svelte.instructions.md
+++ b/.github/instructions/prg-extension-svelte.instructions.md
@@ -16,10 +16,10 @@ Svelte files live **alongside** `index.ts` in the same extension folder and are 
 
 PRG extensions use Svelte for two distinct purposes:
 
-| Type | File naming | Opened via | Purpose |
-|---|---|---|---|
-| **Modal UI Panel** | `MyPanel.svelte` | `this.openUI("MyPanel")` | Full control panels, info views |
-| **Custom Argument** | `MyPicker.svelte` | `this.makeCustomArgument(...)` | Inline block argument selector |
+| Type                | File naming       | Opened via                     | Purpose                         |
+| ------------------- | ----------------- | ------------------------------ | ------------------------------- |
+| **Modal UI Panel**  | `MyPanel.svelte`  | `this.openUI("MyPanel")`       | Full control panels, info views |
+| **Custom Argument** | `MyPicker.svelte` | `this.makeCustomArgument(...)` | Inline block argument selector  |
 
 Both types receive an `extension` prop. Argument components additionally receive `setter` and `current`.
 
@@ -34,7 +34,7 @@ Register `"ui"` as a mixin, then call `openUI()` from any button block:
 ```typescript
 // index.ts
 export default class MyExtension extends extension(details, "ui") {
-  @(scratch.button`Open Control Panel`)
+  @scratch.button`Open Control Panel`
   showPanel(): void {
     this.openUI("Counter", "Panel Title (optional)");
   }
@@ -77,6 +77,7 @@ export default class MyExtension extends extension(details, "ui") {
 ```
 
 **Rules**:
+
 - Always `import type ExtensionClass from "."` — never import the default value directly (avoid circular side-effects)
 - The `extension` prop is always provided; do not assign a default
 - Use Svelte's reactive `$:` statements to sync with extension state
@@ -161,6 +162,7 @@ Call `setter({ value, text })` whenever the user makes a selection:
 ```
 
 **Key rules**:
+
 - `setter()` must be called on every change \u2014 use a reactive `$:` statement
 - `current.value` holds the previous/initial value; read it once on component mount
 - Never mutate `current` directly; always go through `setter`
@@ -271,6 +273,7 @@ extensions/src/my_extension/
 ```
 
 **Naming rules**:
+
 - Modal panels: PascalCase noun (`Counter`, `ColorPicker`, `AnimalCollection`)
 - Argument pickers: PascalCase noun + "Picker" or "Argument" suffix
 - Do **not** create a `ui/` subdirectory \u2014 keep Svelte files flat alongside `index.ts`
@@ -288,13 +291,13 @@ extensions/src/my_extension/
 
 ## Common Errors & Solutions
 
-| Error | Cause | Solution |
-|-------|-------|----------|
-| `extension` is undefined | Wrong import of extension | Use `import type Extension from "."` |
-| `setter` not a function | Prop name mismatch | Ensure prop is `setter`, not `onChange` or similar |
-| Block arg doesn't update | Forgot to call `setter` | Add `$: setter({ value, text })` reactive statement |
-| Component not found | File name mismatch | `openUI("Foo")` requires `Foo.svelte` (case-sensitive) |
-| Style bleeds into Scratch | Global CSS written | Always write styles inside `<style>` in `.svelte` file |
+| Error                         | Cause                     | Solution                                               |
+| ----------------------------- | ------------------------- | ------------------------------------------------------ |
+| `extension` is undefined      | Wrong import of extension | Use `import type Extension from "."`                   |
+| `setter` not a function       | Prop name mismatch        | Ensure prop is `setter`, not `onChange` or similar     |
+| Block arg doesn't update      | Forgot to call `setter`   | Add `$: setter({ value, text })` reactive statement    |
+| Component not found           | File name mismatch        | `openUI("Foo")` requires `Foo.svelte` (case-sensitive) |
+| Style bleeds into Scratch     | Global CSS written        | Always write styles inside `<style>` in `.svelte` file |
 | TypeScript error on prop type | `ParameterOf` wrong index | Check the method signature and 0-based parameter index |
 
 ---

--- a/.github/instructions/prg-extension.instructions.md
+++ b/.github/instructions/prg-extension.instructions.md
@@ -23,24 +23,33 @@ This instruction applies to TypeScript Scratch extensions in the PRG RAISE Playg
 All PRG extensions use **TypeScript decorators** and extend the `extension()` helper. Start with metadata:
 
 ```typescript
-import { extension, scratch, SaveDataHandler, Language, type Environment } from "$common";
+import {
+  type Environment,
+  extension,
+  Language,
+  SaveDataHandler,
+  scratch,
+} from "$common";
 
 const details = {
   name: "My Extension",
   description: "A brief description",
   implementationLanguage: Language.English,
-  blockColor: "#822fbd",  // Hex color for blocks
-  menuColor: "#4ed422",   // Hex color for menu
+  blockColor: "#822fbd", // Hex color for blocks
+  menuColor: "#4ed422", // Hex color for menu
   menuSelectColor: "#9e0d2c",
   tags: ["PRG Internal"],
 };
 
-export default class MyExtension extends extension(details, "ui", "customSaveData") {
+export default class MyExtension
+  extends extension(details, "ui", "customSaveData")
+{
   // Extension state and methods
 }
 ```
 
 **Mixin options**:
+
 - `"ui"` — enables `openUI()` and Svelte component support
 - `"customSaveData"` — enables `SaveDataHandler` for persistence
 - `"customArguments"` — enables custom argument components
@@ -77,6 +86,7 @@ async wait(seconds: number): Promise<void> {
 ```
 
 **Block text rules**:
+
 - Use backtick strings for natural language text
 - Placeholder syntax: `${{ type, defaultValue?, options? }}`
 - Each placeholder becomes a method parameter in order
@@ -85,6 +95,7 @@ async wait(seconds: number): Promise<void> {
 ### 3. Argument Types & Menus
 
 **Built-in argument types**:
+
 - `"string"` — text input with optional dropdown
 - `"number"` — numeric input
 - `"boolean"` — checkbox
@@ -109,13 +120,13 @@ pickFruit(fruit: string): string {
 class MyExtension extends extension(details) {
   animals = {
     items: ["🐕 Dog", "🐈 Cat", "🐘 Elephant"],
-    acceptsReporters: true,  // Allow reporter blocks as input
-    handler: (input: any) => String(input)  // Convert to string
+    acceptsReporters: true, // Allow reporter blocks as input
+    handler: (input: any) => String(input), // Convert to string
   };
 
-  @(scratch.reporter((self, tag) =>
+  @scratch.reporter((self, tag) =>
     tag`Pick this animal: ${{ type: "string", options: self.animals }}`
-  ))
+  )
   pickAnimal(animal: string): string {
     return animal;
   }
@@ -165,6 +176,7 @@ extensions/
 ```
 
 **Best practices**:
+
 - Keep `index.ts` focused on block definitions and state management
 - Move complex logic to separate utility files
 - Co-locate assets (images, icons) with the extension directory
@@ -188,6 +200,7 @@ pnpm new:extension my_awesome_extension barebones
 ```
 
 The command creates:
+
 - `scratch-prg-extensions/extensions/src/my_awesome_extension/index.ts` (main extension file)
 - `scratch-prg-extensions/extensions/src/my_awesome_extension/package.json` (extension metadata)
 - `scratch-prg-extensions/extensions/src/my_awesome_extension/*.svelte` template files (if UI is selected)
@@ -203,6 +216,7 @@ pnpm dev -i my_awesome_extension
 ```
 
 **Options**:
+
 - `-i all` — serve all extensions (resource-intensive)
 - `-i ext1,ext2` — serve multiple specific extensions
 - Watch for TypeScript errors in terminal output
@@ -220,13 +234,13 @@ In browser DevTools Console (F12 → Console):
 
 ```javascript
 // List all registered extensions
-Object.keys(window.scratchExtensions)
+Object.keys(window.scratchExtensions);
 
 // Find your extension
-window.scratchExtensions['My Extension']
+window.scratchExtensions["My Extension"];
 
 // List blocks
-window.scratchVM.runtime.getBlocks()
+window.scratchVM.runtime.getBlocks();
 ```
 
 ### Type Checking
@@ -242,12 +256,14 @@ This runs the TypeScript compiler across all extensions without emitting JavaScr
 ### Testing Extensions
 
 During development:
+
 1. Keep dev server running
 2. Write a simple test block in Scratch
 3. Click the block to trigger your code
 4. Check browser Console for `console.log()` output
 
 **Common issues**:
+
 - Block not appearing? → Check `details.name` matches decorator
 - Decorator not compiling? → Verify template literal syntax
 - Menu not showing? → Ensure `Menu` object has `items` array
@@ -259,12 +275,14 @@ During development:
 ### 1. Function vs. Template Literal Decorators
 
 **Template literal** (static):
+
 ```typescript
 @(scratch.reporter`Answer is ${{ type: "number" }}`)
 add(num: number): number { }
 ```
 
 **Function** (dynamic, access to `self`):
+
 ```typescript
 @(scratch.reporter((self, tag) =>
   tag`Pick ${{ type: "string", options: self.animals }}`
@@ -283,12 +301,12 @@ const details = {
   name: "My Extension",
   [Language.Español]: {
     name: "Mi Extensión",
-    description: "Descripción en español"
+    description: "Descripción en español",
   },
   [Language.Français]: {
     name: "Mon Extension",
     // ...
-  }
+  },
 };
 ```
 
@@ -306,6 +324,7 @@ imageBlock(img: "inline image"): string {
 ```
 
 **Notes**:
+
 - `flipRTL: true` flips image for right-to-left languages
 - Import images at the top; type checker ensures they're valid
 - Use `"inline image"` as the parameter type
@@ -322,6 +341,7 @@ getBlockID({ blockID }: BlockUtilityWithID): string {
 ```
 
 **Available utilities**:
+
 - `BlockUtilityWithID` — provides `blockID` (unique identifier for this block instance)
 
 ### 5. Asynchronous Blocks
@@ -395,7 +415,7 @@ const safeFruit = (input: any): Fruit => {
   } catch (e) {
     console.warn(`Invalid fruit input: ${input}`);
   }
-  return Fruit.Apple;  // Safe default
+  return Fruit.Apple; // Safe default
 };
 ```
 
@@ -463,6 +483,7 @@ test(): void {
 ```
 
 **Check for**:
+
 - TypeScript compilation errors reported by webpack
 - Extension load messages
 - Your extension's console output
@@ -473,7 +494,7 @@ The Scratch VM uses Redux. View state changes:
 
 ```javascript
 // In browser console
-window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
 ```
 
 This helps debug complex state interactions.
@@ -486,13 +507,13 @@ This helps debug complex state interactions.
 
 ### Common Errors & Solutions
 
-| Error | Cause | Solution |
-|-------|-------|----------|
-| "Block not found" | Decorator/name mismatch | Verify `details.name` matches your block names |
-| Block appears but doesn't work | Implementation error | Check browser console for exceptions |
-| Menu items not showing | `options` is undefined | Ensure `Menu.items` is populated in `init()` |
-| Type error on decorator | Template literal syntax | Use backticks and `${{ }}` syntax correctly |
-| Svelte component not rendering | Missing props | See `prg-extension-svelte` instructions for required props |
-| Stale changes after edit | Dev server cache | Kill dev server and restart `pnpm dev` |
+| Error                          | Cause                   | Solution                                                   |
+| ------------------------------ | ----------------------- | ---------------------------------------------------------- |
+| "Block not found"              | Decorator/name mismatch | Verify `details.name` matches your block names             |
+| Block appears but doesn't work | Implementation error    | Check browser console for exceptions                       |
+| Menu items not showing         | `options` is undefined  | Ensure `Menu.items` is populated in `init()`               |
+| Type error on decorator        | Template literal syntax | Use backticks and `${{ }}` syntax correctly                |
+| Svelte component not rendering | Missing props           | See `prg-extension-svelte` instructions for required props |
+| Stale changes after edit       | Dev server cache        | Kill dev server and restart `pnpm dev`                     |
 
 ---

--- a/.github/prompts/new-prg-extension.prompt.md
+++ b/.github/prompts/new-prg-extension.prompt.md
@@ -35,7 +35,7 @@ Generate the following files:
 Use this exact structure:
 
 ```typescript
-import { extension, scratch, Language, type Environment } from "$common";
+import { type Environment, extension, Language, scratch } from "$common";
 
 const details = {
   name: "<Extension Display Name>",
@@ -47,7 +47,7 @@ const details = {
   tags: ["Arduino Modulino"],
 };
 
-export default class <ClassName> extends extension(details<mixins>) {
+export default class<ClassName> extends extension(details<mixins>) {
   // State fields here
 
   async init(env: Environment): Promise<void> {
@@ -59,6 +59,7 @@ export default class <ClassName> extends extension(details<mixins>) {
 ```
 
 Rules for block generation:
+
 - Each block must use the `@scratch.command`, `@scratch.reporter`, or `@scratch.button` decorator
 - Use template literal form for static blocks; function form `(self, tag) => tag\`...\`` when the block needs dynamic options from extension state
 - Each placeholder `${{ type, defaultValue?, options? }}` maps to one method parameter in order

--- a/app/sketch/sketch.yaml
+++ b/app/sketch/sketch.yaml
@@ -4,12 +4,6 @@ profiles:
     platforms:
       - platform: arduino:zephyr
     libraries:
-      - dependency: Arduino_RPClite (0.2.1)
-      - Arduino_RouterBridge (0.4.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
       - dependency: ArduinoGraphics (1.1.5)
       - dependency: Arduino_HS300x (1.0.0)
       - dependency: Arduino_LPS22HB (1.0.2)
@@ -19,4 +13,5 @@ profiles:
       - dependency: STM32duino VL53L4CD (1.0.5)
       - dependency: STM32duino VL53L4ED (1.0.1)
       - Servo (1.3.0)
+
 default_profile: default


### PR DESCRIPTION
The routerBridge is not needed in the `sketch.yaml` file starting from arduino:zephyr > 0.55